### PR TITLE
MINOR: blog description just below page title

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,6 +3,9 @@
         <div id="header-inner" class="inner">
             <a id="main-nav-toggle" class="nav-icon" href="javascript:;"></a>
             <a id="logo" class="logo-text" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+            {{ if .Site.Params.showPageSubtitle }}
+            <div class="logo-subtext">{{ .Site.Params.Description }}</div>
+            {{ end }}
             <nav id="main-nav">
                 {{ range .Site.Menus.main }}
                 <a class="main-nav-link" href="{{ .URL }}">{{ .Name }}</a>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -168,6 +168,15 @@ body {
   text-decoration: none;
   background-image: none;
 }
+.logo-subtext {
+  width: auto;
+  color: #ccc;
+  float: left;
+  font-size: 16px;
+  font-weight: 700;
+  text-decoration: none;
+  background-image: none;
+}
 .article-meta a,
 a.article-title,
 .article-entry a,


### PR DESCRIPTION
This PR offers:
* site description as a subtitle just below page logo text was added
* configurable by setting **showPageSubtitle** in config file (*params* section)

Resolving this issue: https://github.com/carsonip/hugo-theme-minos/issues/7