### PR TITLE
Use absURL for CSS links

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,10 +9,10 @@
     <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     <link rel="shortcut icon" href="/favicon.png">
 
-    <link href="{{ .Site.BaseURL }}webfonts/ptserif/main.css" rel='stylesheet' type='text/css'>
-    <link href="{{ .Site.BaseURL }}webfonts/source-code-pro/main.css" rel="stylesheet" type="text/css">
-
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
+    <link href="{{ "webfonts/ptserif/main.css" | absURL }}" rel='stylesheet' type='text/css'>
+    <link href="{{ "webfonts/source-code-pro/main.css" | absURL }}" rel="stylesheet" type="text/css">
+    
+    <link rel="stylesheet" href="{{ "css/style.css" | absURL }}">
 
     <link href="http://gmpg.org/xfn/11" rel="profile">
     


### PR DESCRIPTION
Use `absURL` for CSS links, so that theme users can have a `baseURL` value with or without a trailing slash

Fixes #18 