### PR TITLE
Fixing disqus shortname config location for newer versions of hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ paginate = 10
 
 ### Disqus
 ```
-[params]
-    disqusShortname = "xxxxxx"
+disqusShortname = "xxxxxx"
 ```
 
 ### Google Analytics

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
     {{ partial "header.html" . }}
     <section id="main" class="outer">
         {{ partial "article.html" . }}
-        {{ if and (not .Params.nocomment) .Site.Params.disqusShortname }}
+        {{ if and (not .Params.nocomment) .Site.DisqusShortname }}
             {{ template "_internal/disqus.html" . }}
         {{ end }}
     </section>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,7 +29,7 @@
                         </div>
                     </div>
                     {{ end }}
-                    {{ if .Site.Params.disqusShortname }}
+                    {{ if .Site.DisqusShortname }}
                     <div class="article-comment-link-wrap">
                         <a href="{{ .RelPermalink }}#disqus_thread" class="article-comment-link">Comments</a>
                     </div>

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -22,7 +22,7 @@
                 </div>
             </div>
             {{ end }}
-            {{ if .Site.Params.disqusShortname }}
+            {{ if .Site.DisqusShortname }}
             <div class="article-comment-link-wrap">
                 <a href="{{ .RelPermalink }}#disqus_thread" class="article-comment-link">Comments</a>
             </div>


### PR DESCRIPTION
Newer versions of hugo have disqusShortname at the top level of the site config, not within params section. The internal disqus template doesn't work with the disqusShortname set in params because it uses {{ .Site.DisqusShortname }}

Updated usages of {{ .Site.Params.disqusShortname }} to {{ .Site.DisqusShortname }}