### PR TITLE
Enhance KaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ hidden = true
 ```
 
 ### Enable KaTeX for this post
-This can be used when creating an "About me"-page.
+Enable KaTeX for a specific post without enabling the global switch.
 ```
 +++
 katex = true

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ hidden = true
 +++
 ```
 
+### Enable KaTeX for this post
+This can be used when creating an "About me"-page.
+```
++++
+katex = true
++++
+```
+
 ## Contributing
 
 1. Fork it!

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,6 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.js" integrity="sha384-/y1Nn9+QQAipbNQWU65krzJralCnuOasHncUFXGkdwntGeSvQicrYkiUBwsgUqc1" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha256-ExtbCSBuYA7kq1Pz362ibde9nnsHYPt6JxuxYeZbU+c=" crossorigin="anonymous"></script>
         <script>renderMathInElement(document.body);</script>
-        <script>for (element of document.getElementsByClassName("language-katex")) { renderMathInElement(element); }</script>
     {{ end }}
     <script>
         document.getElementById('main-nav-toggle').addEventListener('click', function () {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,6 +17,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.js" integrity="sha384-/y1Nn9+QQAipbNQWU65krzJralCnuOasHncUFXGkdwntGeSvQicrYkiUBwsgUqc1" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha256-ExtbCSBuYA7kq1Pz362ibde9nnsHYPt6JxuxYeZbU+c=" crossorigin="anonymous"></script>
         <script>renderMathInElement(document.body);</script>
+        <script>for (element of document.getElementsByClassName("language-katex")) { renderMathInElement(element); }</script>
     {{ end }}
     <script>
         document.getElementById('main-nav-toggle').addEventListener('click', function () {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,7 +12,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js" integrity="sha256-KbfTjB0WZ8vvXngdpJGY3Yp3xKk+tttbqClO11anCIU=" crossorigin="anonymous"></script>
     <script>hljs.initHighlightingOnLoad();</script>
 
-    {{ if .Site.Params.Katex }}
+    {{ if $.Param "katex" }}
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css" integrity="sha384-wITovz90syo1dJWVh32uuETPVEtGigN07tkttEqPv+uR2SE/mbQcG7ATL28aI9H0" crossorigin="anonymous">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.js" integrity="sha384-/y1Nn9+QQAipbNQWU65krzJralCnuOasHncUFXGkdwntGeSvQicrYkiUBwsgUqc1" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha256-ExtbCSBuYA7kq1Pz362ibde9nnsHYPt6JxuxYeZbU+c=" crossorigin="anonymous"></script>


### PR DESCRIPTION
There are two modifications:

1. Use `.Param` as switch of KaTeX to enable KaTeX for whole site or for single post. Sample configuration is available in `README.md`.
2. Enable rendering KaTeX in code block.