### PR TITLE
Update functions deprecated in Hugo 0.55

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
     {{ partial "meta.html" . }}
     {{ partial "og.html" . }}
 
-    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ with .OutputFormats.Get "RSS" }}{{ .Permalink }}{{ end }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     <link rel="shortcut icon" href="/favicon.png">
 
     <link href="{{ "webfonts/ptserif/main.css" | absURL }}" rel='stylesheet' type='text/css'>
@@ -14,5 +14,5 @@
 
     <link rel="stylesheet" href="{{ "css/style.css" | absURL }}">
 
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
 </head>


### PR DESCRIPTION
Following functions are deprecated in Hugo 0.55:

* Page's .RSSLink
* Page's .Hugo